### PR TITLE
use new plugin (for old v1 plugins) include path

### DIFF
--- a/inspec-iggy.gemspec
+++ b/inspec-iggy.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "inspec", ">=2.0", "<3.0.0"
+  spec.add_dependency "inspec", ">=2.2.64", "<3.0.0"
 end

--- a/lib/inspec-iggy/cli.rb
+++ b/lib/inspec-iggy/cli.rb
@@ -5,7 +5,7 @@
 # Copyright:: 2018, Chef Software, Inc <legal@chef.io>
 #
 
-require "inspec/plugins"
+require "inspec/plugin/v1"
 require "thor"
 
 require "inspec-iggy/terraform"


### PR DESCRIPTION
With inspec/inspec#3278 we introduced new include paths for plugins in preparation for our new plugin mechanism. This updates iggy to use that new plugin includes